### PR TITLE
Created API Routes

### DIFF
--- a/app/api/route.tsx
+++ b/app/api/route.tsx
@@ -1,0 +1,27 @@
+/*Use App Router to further develop APIs since the original codebase is in /app
+Doc: https://nextjs.org/docs/app/building-your-application/routing/router-handlers
+
+You can interact with the API by passing a parameter in the URL like https://yt.playlister.vercel.app/api?url=[URL of YouTube Playlist]
+To get a response in the format of {
+  "parsedData": {
+    "noOfVideos": [number],
+    "totalLength": [string] ,
+    "avgLength": [string] ,
+    "at1.25x": [string] ,
+    "at1.50x": [string] ,
+    "at1.75x": [string] ,
+    "at2.00x": [string] ,
+  }
+}
+The [string] will be in the format "[n] hours [n] minutes [n] seconds" where [n] is a [number]
+*/
+
+import { NextResponse, NextRequest } from 'next/server'
+import fetchPlaylistDetails from "../functions/HandleRequest";
+
+export async function GET(request: NextRequest) {
+    //const mysearchparam = request.nextUrl.searchParams.get('mysearchparam')
+    const url  = request.nextUrl.searchParams.get('url')
+    const parsedData = await fetchPlaylistDetails(url)
+    return NextResponse.json({parsedData})
+}

--- a/app/functions/HandleRequest.ts
+++ b/app/functions/HandleRequest.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { toast } from "sonner";
 
 export default async function fetchPlaylistDetails(
-    playlistUrl: string
+    playlistUrl: string | null
 ): Promise<any> {
     const playlistId = extractPlaylistId(playlistUrl);
     if (!playlistId) {
@@ -31,7 +31,7 @@ export default async function fetchPlaylistDetails(
     return parsedData;
 }
 
-const extractPlaylistId = (playlistUrl: string) => {
+const extractPlaylistId = (playlistUrl: string | null) => {
     if (playlistUrl) {
         const reg = /[&?]list=([^&]+)/i;
         const match = reg.exec(playlistUrl);


### PR DESCRIPTION
Fixes Issue #4 

The project used App Router instead of the traditional Page Router of Next.js, the API created follows the [App Router API Reference](https://nextjs.org/docs/app/api-reference)
You can interact with the API by passing a parameter in the URL like `https://yt.playlister.vercel.app/api?url=[URL of YouTube Playlist]`
To get a response in the format of
```
{
  "parsedData": {
    "noOfVideos": [number],
    "totalLength": [string] ,
    "avgLength": [string] ,
    "at1.25x": [string] ,
    "at1.50x": [string] ,
    "at1.75x": [string] ,
    "at2.00x": [string] ,
  }
}
```
The [string] will be in the format "[n] hours [n] minutes [n] seconds" where [n] is a [number]

The parameter `playlistUrl` initially a `string` was updated to string or null `string | null`.

API tested successfully locally on @hoppscotch using a private YouTube Data API Key.
![image](https://github.com/marahim20/playlister/assets/83979298/be907154-7040-441a-ab43-696e73562edb)

